### PR TITLE
feat: allow log configuration

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -82,6 +82,8 @@ export abstract class Storage<Reference, AttachedData> {
 	 */
 	readonly dynamicCompressionMinLength: number;
 
+	private readonly console: NonNullable<StorageOptions['console']>;
+
 	/**
 	 * Create storage
 	 *
@@ -109,6 +111,7 @@ export abstract class Storage<Reference, AttachedData> {
 		this.defaultMimeType = opts.defaultMimeType ?? false;
 		this.maxRanges = opts.maxRanges ?? DEFAULT_MAX_RANGES;
 		this.weakEtags = opts.weakEtags === true;
+		this.console = opts.console ?? global.console;
 	}
 
 	/**
@@ -553,7 +556,7 @@ export abstract class Storage<Reference, AttachedData> {
 				}),
 				err => {
 					if (err) {
-						console.error('Broti compress failed.', err);
+						this.console.error('Broti compress failed.', err);
 					}
 				},
 			);
@@ -568,7 +571,7 @@ export abstract class Storage<Reference, AttachedData> {
 				zlib.createGzip({ level: 6 }),
 				err => {
 					if (err) {
-						console.error('Gzip failed.', err);
+						this.console.error('Gzip failed.', err);
 					}
 				},
 			);

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,9 +156,15 @@ export interface StorageOptions {
 	/**
 	 * Sets the minimum length of a response that will be dynamically compressed (only when the length is known)
 	 *
-	 * Default to 20
+	 * Defaults to 20
 	 */
 	dynamicCompressionMinLength?: number;
+	/**
+	 * Console object to use for logging
+	 * 
+	 * Defaults to global.console
+	 */
+	console?: Partial<Console> & { error: Console['error'] };
 }
 
 /**


### PR DESCRIPTION
I noticed error logs popping up from time to that can't be easily silenced. This adds a `console` option allowing users to override the existing error logs:

```ts
const storage = new FileSystemStorage('/', {
    console: {
      error: () => {}
    }
});
```